### PR TITLE
refactor: simplify MoveTool updateCursor method

### DIFF
--- a/src/editor/tools/move-tool.js
+++ b/src/editor/tools/move-tool.js
@@ -15,7 +15,6 @@ class MoveTool extends BaseTool {
    * Updates cursor to move/grab cursor
    */
   updateCursor() {
-    this.canvas.classList.remove('cursor-default', 'cursor-move', 'cursor-text', 'cursor-crosshair');
     this.canvas.style.cursor = 'grab';
   }
 


### PR DESCRIPTION
Remove redundant classList.remove() call since inline style cursor has higher specificity than CSS classes. This improves maintainability and eliminates unnecessary DOM operations.